### PR TITLE
Adding commands to ZaupFeast

### DIFF
--- a/Commands/CommandResetFeast.cs
+++ b/Commands/CommandResetFeast.cs
@@ -29,7 +29,7 @@ namespace Zamirathe_Feast.Commands
         {
             get
             {
-                return "Resets the feast";
+                return "Resets the feast.";
             }
         }
         public string Syntax
@@ -43,7 +43,7 @@ namespace Zamirathe_Feast.Commands
         // Run the command.
         public void Execute(RocketPlayer caller, string[] command)
         {
-            Utils.Respond(caller, "Resetting the feast!");
+            Utils.Respond(caller, "Resetting the feast.");
             Feast feast = Feast.Instance;
             feast.resetFeast();
         }

--- a/Commands/CommandResetFeast.cs
+++ b/Commands/CommandResetFeast.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Rocket.Unturned;
+using Rocket.Unturned.Commands;
+using Rocket.Unturned.Player;
+using Rocket.Unturned.Plugins;
+using Rocket.Core.Logging;
+
+namespace Zamirathe_Feast.Commands
+{
+    public class CommandResetFeast : IRocketCommand
+    {
+        public bool RunFromConsole
+        {
+            get
+            {
+                return true;
+            }
+        }
+        public string Name
+        {
+            get
+            {
+                return "resetfeast";
+            }
+        }
+        public string Help
+        {
+            get
+            {
+                return "Resets the feast";
+            }
+        }
+        public string Syntax
+        {
+            get { return ""; }
+        }
+        public List<string> Aliases
+        {
+            get { return new List<string> { "freset" }; }
+        }
+        // Run the command.
+        public void Execute(RocketPlayer caller, string[] command)
+        {
+            Utils.Respond(caller, "Resetting the feast!");
+            Feast feast = Feast.Instance;
+            feast.resetFeast();
+        }
+    }
+}

--- a/Commands/CommandRunFeast.cs
+++ b/Commands/CommandRunFeast.cs
@@ -28,7 +28,7 @@ namespace Zamirathe_Feast.Commands{
         {
             get
             {
-                return "Immediately starts the feast";
+                return "Immediately starts the feast.";
             }
         }
         public string Syntax
@@ -42,7 +42,7 @@ namespace Zamirathe_Feast.Commands{
         // Run the command.
         public void Execute(RocketPlayer caller, string[] command)
         {
-            Utils.Respond(caller, "Starting the feast");
+            Utils.Respond(caller, "Starting the feast.");
             Feast feast = Feast.Instance;
             feast.runFeast();
         }

--- a/Commands/CommandRunFeast.cs
+++ b/Commands/CommandRunFeast.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Rocket.Unturned;
+using Rocket.Unturned.Commands;
+using Rocket.Unturned.Player;
+using Rocket.Unturned.Plugins;
+using Rocket.Core.Logging;
+
+namespace Zamirathe_Feast.Commands{
+    public class CommandRunFeast : IRocketCommand
+    {
+        public bool RunFromConsole
+        {
+            get
+            {
+                return true;
+            }
+        }
+        public string Name
+        {
+            get
+            {
+                return "runfeast";
+            }
+        }
+        public string Help
+        {
+            get
+            {
+                return "Immediately starts the feast";
+            }
+        }
+        public string Syntax
+        {
+            get { return "";}
+        }
+        public List<string> Aliases
+        {
+            get { return new List<string> { "frun" }; }
+        }
+        // Run the command.
+        public void Execute(RocketPlayer caller, string[] command)
+        {
+            Utils.Respond(caller, "Starting the feast");
+            Feast feast = Feast.Instance;
+            feast.runFeast();
+        }
+    }
+}

--- a/Commands/CommandSetFeast.cs
+++ b/Commands/CommandSetFeast.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using Rocket.Unturned;
+using Rocket.Unturned.Commands;
+using Rocket.Unturned.Player;
+using Rocket.Unturned.Plugins;
+using Rocket.Core.Logging;
+
+namespace Zamirathe_Feast.Commands
+{
+    public class CommandSetFeast : IRocketCommand
+    {
+        public bool RunFromConsole
+        {
+            get
+            {
+                return true;
+            }
+        }
+        public string Name
+        {
+            get
+            {
+                return "setfeast";
+            }
+        }
+        public string Help
+        {
+            get
+            {
+                return "Set the next feast to location. Use parameter";
+            }
+        }
+        public string Syntax
+        {
+            get { return ""; }
+        }
+        public List<string> Aliases
+        {
+            get { return new List<string> { "fset" }; }
+        }
+        // Run the command.
+        public class loc
+        {
+           internal bool isLocation;
+           internal bool isMapLocation;
+           internal Locs listLoc;
+
+            public loc(bool a, bool b, Locs c)
+            {
+                isLocation = a;
+                isMapLocation = b;
+                listLoc = c;
+            }
+        }
+
+        public loc CheckLoc(string location_name)
+        {
+            Feast feast = Feast.Instance;
+
+            Locs locResultObj = feast.getLocations().FirstOrDefault(a => a.Name() == location_name);
+            Locs mapResultObj = feast.getMapLocations().FirstOrDefault(b => b.Name() == location_name);
+
+            bool locResult = (locResultObj != null);
+            bool mapResult = (mapResultObj != null);
+
+            return new loc(locResult, mapResult, mapResultObj);
+        }
+
+        public void Execute(RocketPlayer caller, string[] command)
+        {
+            Feast feast = Feast.Instance;
+
+
+            if (command.Length > 2 || command.Length == 0)
+            {
+                // Not enough, or too many params.
+                Utils.Respond(caller, "Wrong usage of command setfeast.");
+            }
+            else if (command.Length == 2)
+            {
+                // Two params. Is one of them f? 
+                if (command[1] != "f" && command[0] != "f")
+                {
+                    // Nope, that's no good.
+                   Utils.Respond(caller, "Wrong usage of command setfeast.");
+                }
+                else
+                {
+                    string location = (command[0]=="f") ? command[1] : command[0];
+                    loc locReturn = CheckLoc(location);
+                    if (locReturn.isMapLocation)
+                    {
+                        Utils.Respond(caller, "Forcing feast location of " + location);
+                        feast.setNextLocation(locReturn.listLoc);
+                    }
+                    else
+                    {
+                        Utils.Respond(caller, "Location not on map!");
+                    }
+
+                }
+            }
+            else
+            {
+                // One parameter.
+                string location = command[0];
+                loc locReturn = CheckLoc(location);
+                if (locReturn.isLocation)
+                {
+                    Utils.Respond(caller, "Setting the feast to "+locReturn.listLoc.Name());
+                    feast.setNextLocation(locReturn.listLoc);
+                }
+                else
+                if (locReturn.isMapLocation)
+                {
+                    Utils.Respond(caller, "Location not a part of Feast locations. Use f parameter to force.");
+                }
+                else
+                {
+                    Utils.Respond(caller, "Location not on map.");
+                }
+            }
+        }
+    }
+
+}

--- a/Commands/CommandSetFeast.cs
+++ b/Commands/CommandSetFeast.cs
@@ -30,7 +30,7 @@ namespace Zamirathe_Feast.Commands
         {
             get
             {
-                return "Set the next feast to location. Use parameter";
+                return "Set the next feast to location. Use parameter f to force a location not in config.";
             }
         }
         public string Syntax
@@ -93,12 +93,12 @@ namespace Zamirathe_Feast.Commands
                     loc locReturn = CheckLoc(location);
                     if (locReturn.isMapLocation)
                     {
-                        Utils.Respond(caller, "Forcing feast location of " + location);
+                        Utils.Respond(caller, "Forcing feast location of " + location+".");
                         feast.setNextLocation(locReturn.listLoc);
                     }
                     else
                     {
-                        Utils.Respond(caller, "Location not on map!");
+                        Utils.Respond(caller, "Location not on map.");
                     }
 
                 }

--- a/Commands/Utils.cs
+++ b/Commands/Utils.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Rocket.Unturned;
+using Rocket.Unturned.Commands;
+using Rocket.Unturned.Player;
+using Rocket.Unturned.Plugins;
+using Rocket.Core.Logging;
+
+namespace Zamirathe_Feast.Commands
+{
+    public static class Utils
+    {
+        public static void Respond(RocketPlayer caller, String message)
+        {
+            if (caller == null){
+                Logger.Log(message);
+            }else{
+                RocketChat.Say(caller, message);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -122,11 +122,17 @@ All items are set to be removed when Unturned itself looks to sweep items that h
 
 ## Commands ##
 This version of ZaupFeast features three new commands courtesy of nicholaiii <nicholainissen@gmail.com>. 
+
 **ResetFeast**: Resets the Feast, resetting time and locations as according to your settings, as if it has just been run. *Alias: freset*
+
 *Example usage*: `/resetfeast
+
 **RunFeast**: Starts the Feast immediately at the  chosen location. *Alias: frun* 
+
 *Example usage*: `/runfeast
+
 **SetFeast**: Sets the desired location of the feast. Use the f parameter to force a location that is not included in the config. *Alias: fset*
+
 *Example usage*: `/setfeast f SomeTown
 
 *If you delete the configuration file, the system will recreate it on a restart but it will print a warning that it could not find it and disable the feast.  Just edit your config and restart the server. *

--- a/README.md
+++ b/README.md
@@ -111,13 +111,21 @@ Here is my take on the old Feast that was available for 2.2.5.  My version, you 
 Most of these should be self explanatory.
 ## Configuration nodes ##
 **enabled:** set to false if you really want to turn the feast off but not remove it from your server.
+
 **minDropTime** and **maxDropTime** is the range of time between feast drops in seconds.  If you set both to the same number, it will be a set time.
+
 **dropRadius** is how far from the location point they should randomly drop.  Default is 20 spaces.
+
 **minItemsDrop** and **maxItemsDrop** is the range of number of items to be dropped each time.
+
 **skyDrop** and **skyDropRadius**:  If set to true, the items will then spawn anywhere between 1 and the amount set on skyDropRadius in the air and fall to the ground.  Yes, they can fall on roofs.
+
 **FeastItem** is a required piece.  It gives all the info the feast needs to drop a certain type.  Name doesn't have to be exact, but id does.  Chance is how many times to add that id into the pot.  10 is default for 10 types.  (10 items, 10 times each, makes it 10% chance each item will be this specific item.)
+
 **Locations** is the most configurable.  Just put all, and that item will drop at all locations, or you can specify 1 or more locations for that item to drop.  So you can have items drop in one location and not another.  The names come from the map nodes, and they do have to be exact to take.
+
 The two messages are what is sent to global chat before and during a feast.
+
 All items are set to be removed when Unturned itself looks to sweep items that have been moved.  A message will be printed to the console that has the time and location of the next feast for logging purposes.
 
 ## Commands ##
@@ -125,14 +133,14 @@ This version of ZaupFeast features three new commands courtesy of nicholaiii <ni
 
 **ResetFeast**: Resets the Feast, resetting time and locations as according to your settings, as if it has just been run. *Alias: freset*
 
-*Example usage*: `/resetfeast
+*Example usage*: `/resetfeast`
 
 **RunFeast**: Starts the Feast immediately at the  chosen location. *Alias: frun* 
 
-*Example usage*: `/runfeast
+*Example usage*: `/runfeast`
 
 **SetFeast**: Sets the desired location of the feast. Use the f parameter to force a location that is not included in the config. *Alias: fset*
 
-*Example usage*: `/setfeast f SomeTown
+*Example usage*: `/setfeast f SomeTown`
 
 *If you delete the configuration file, the system will recreate it on a restart but it will print a warning that it could not find it and disable the feast.  Just edit your config and restart the server. *

--- a/README.md
+++ b/README.md
@@ -109,15 +109,24 @@ Here is my take on the old Feast that was available for 2.2.5.  My version, you 
 ```
 
 Most of these should be self explanatory.
-
-enabled: set to false if you really want to turn the feast off but not remove it from your server.
-minDropTime and maxDropTime is the range of time between feast drops in seconds.  If you set both to the same number, it will be a set time.
-dropRadius is how far from the location point they should randomly drop.  Default is 20 spaces.
-minItemsDrop and maxItemsDrop is the range of number of items to be dropped each time.
-skyDrop and skyDropRadius:  If set to true, the items will then spawn anywhere between 1 and the amount set on skyDropRadius in the air and fall to the ground.  Yes, they can fall on roofs.
-FeastItem is a required piece.  It gives all the info the feast needs to drop a certain type.  Name doesn't have to be exact, but id does.  Chance is how many times to add that id into the pot.  10 is default for 10 types.  (10 items, 10 times each, makes it 10% chance each item will be this specific item.)
-Locations is the most configurable.  Just put all, and that item will drop at all locations, or you can specify 1 or more locations for that item to drop.  So you can have items drop in one location and not another.  The names come from the map nodes, and they do have to be exact to take.
+## Configuration nodes ##
+**enabled:** set to false if you really want to turn the feast off but not remove it from your server.
+**minDropTime** and **maxDropTime** is the range of time between feast drops in seconds.  If you set both to the same number, it will be a set time.
+**dropRadius** is how far from the location point they should randomly drop.  Default is 20 spaces.
+**minItemsDrop** and **maxItemsDrop** is the range of number of items to be dropped each time.
+**skyDrop** and **skyDropRadius**:  If set to true, the items will then spawn anywhere between 1 and the amount set on skyDropRadius in the air and fall to the ground.  Yes, they can fall on roofs.
+**FeastItem** is a required piece.  It gives all the info the feast needs to drop a certain type.  Name doesn't have to be exact, but id does.  Chance is how many times to add that id into the pot.  10 is default for 10 types.  (10 items, 10 times each, makes it 10% chance each item will be this specific item.)
+**Locations** is the most configurable.  Just put all, and that item will drop at all locations, or you can specify 1 or more locations for that item to drop.  So you can have items drop in one location and not another.  The names come from the map nodes, and they do have to be exact to take.
 The two messages are what is sent to global chat before and during a feast.
 All items are set to be removed when Unturned itself looks to sweep items that have been moved.  A message will be printed to the console that has the time and location of the next feast for logging purposes.
 
-If you delete the configuration file, the system will recreate it on a restart but it will print a warning that it could not find it and disable the feast.  Just edit your config and restart the server.  
+## Commands ##
+This version of ZaupFeast features three new commands courtesy of nicholaiii <nicholainissen@gmail.com>. 
+**ResetFeast**: Resets the Feast, resetting time and locations as according to your settings, as if it has just been run. *Alias: freset*
+*Example usage*: `/resetfeast
+**RunFeast**: Starts the Feast immediately at the  chosen location. *Alias: frun* 
+*Example usage*: `/runfeast
+**SetFeast**: Sets the desired location of the feast. Use the f parameter to force a location that is not included in the config. *Alias: fset*
+*Example usage*: `/setfeast f SomeTown
+
+*If you delete the configuration file, the system will recreate it on a restart but it will print a warning that it could not find it and disable the feast.  Just edit your config and restart the server. *

--- a/ZaupFeast.cs
+++ b/ZaupFeast.cs
@@ -87,7 +87,7 @@ namespace Zamirathe_Feast
             List<int> list = new List<int>();
             foreach (FeastItem current in feast.items)
             {
-                if (current.Location.Contains(feast.nextLocation.Name()) || !current.Location.Contains("all") || !current.Location.Contains("All")) 
+                if (current.Location.Contains(feast.nextLocation.Name()) || current.Location.Contains("all") || current.Location.Contains("All")) 
                 {
                     for (byte b = 0; b < current.Chance; b += 1)
                     {

--- a/ZaupFeast.cs
+++ b/ZaupFeast.cs
@@ -13,6 +13,7 @@ namespace Zamirathe_Feast
     {
         private DateTime lastFeast;
         private DateTime nextFeast;
+        private List<Locs> maplocations;
         private List<Locs> locations;
         private List<FeastItem> items;
         private Locs nextLocation;
@@ -36,7 +37,7 @@ namespace Zamirathe_Feast
         {
             Feast.instance = this;
             this.locations = new List<Locs>();
-            List<Locs> maplocations = new List<Locs>();
+            this.maplocations = new List<Locs>();
             if (LevelNodes.Nodes == null)
             {
                 LevelNodes.load();
@@ -79,7 +80,7 @@ namespace Zamirathe_Feast
             this.running = true;
             this.resetFeast();
         }
-        private void runFeast()
+        public void runFeast()
         {
             Feast feast = Feast.instance;
             int num = UnityEngine.Random.Range((int)feast.Configuration.minItemsDrop, (int)feast.Configuration.maxItemsDrop+1);
@@ -148,6 +149,18 @@ namespace Zamirathe_Feast
         {
             Feast feast = Feast.instance;
             if (feast.Configuration.Enabled && feast.running) feast.checkFeast();
+        }
+        public List<Locs> getMapLocations()
+        {
+            return maplocations;
+        }
+        public List<Locs> getLocations()
+        {
+            return locations;
+        }
+        public void setNextLocation(Locs loc)
+        {
+           nextLocation = loc;
         }
     }
 }

--- a/ZaupFeast.csproj
+++ b/ZaupFeast.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ZaupFeast</RootNamespace>
     <AssemblyName>ZaupFeast</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -59,7 +62,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -69,11 +71,18 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\CommandResetFeast.cs" />
+    <Compile Include="Commands\CommandSetFeast.cs" />
+    <Compile Include="Commands\Utils.cs" />
+    <Compile Include="Commands\CommandRunFeast.cs" />
     <Compile Include="ZaupFeast.cs" />
     <Compile Include="ZaupFeastConfiguration.cs" />
     <Compile Include="FeastItem.cs" />
     <Compile Include="Locs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
I've added three user commands, at least one of them asked for on dev.rocket, as well as some minor changes;

runfeast - starts the feast right away
resetfeast - resets the feast
setfeast - set feast location

They all work as expected. setfeast takes a location from the config unless (by using the f param) forced to accept a maplocation.

I've added three functions to the main class, getLocations, getMapLocations and setNextLocation, the first two returns the private variables of the same name and the last one sets the private variable of the same name. These are used in the setfeast command.

I've added a Utils class for a Respond function to send a message back to the caller of the command, be it either console or player, without worrying about the caller in the commands themselves. It takes a caller argument and a message, and sends the response to either log (if console) or player. 

Also i've made the readme a bit easier to read and added descriptions for the commands.
